### PR TITLE
chore: Upgrade requests to 2.21.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 asn1crypto==0.24.0
 beautifulsoup4==4.6.0
 boto==2.47.0
+certifi==2018.11.29
 cffi==1.11.5
+chardet==3.0.4
 coverage==4.5.2
 coveralls==1.5.1
 cryptography==2.4.2
@@ -41,7 +43,7 @@ pytz==2018.9
 raven==6.9.0
 rcssmin==1.0.6
 redis==3.0.1
-requests==2.13.0
+requests==2.21.0
 requests-oauthlib==1.2.0
 rjsmin==1.0.12
 rsa==4.0


### PR DESCRIPTION
Upgraded to avoid security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2018-18074