### PR TITLE
chore: Upgrade Django to 2.0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ coverage==4.5.2
 coveralls==1.5.1
 cryptography==2.4.2
 dj-database-url==0.5.0
-Django==2.0.9
+Django==2.0.10
 django-appconf==1.0.2
 django-compressor==2.1.1
 django-dotenv==1.4.1


### PR DESCRIPTION
Upgraded to avoid security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2019-3498