### PR TITLE
fix: Use database for search until Elasticsearch is updated

### DIFF
--- a/opencanada/settings/production.py
+++ b/opencanada/settings/production.py
@@ -11,21 +11,26 @@ PREPEND_WWW = False # TODO: Set to true for production
 
 ALLOWED_HOSTS = [get_env_variable('ALLOWED_HOSTS')]
 
+# WAGTAILSEARCH_BACKENDS = {
+#     'default': {
+#         'BACKEND': 'wagtail.search.backends.elasticsearch2',
+#         'INDEX': get_env_variable('ELASTICSEARCH_INDEX'),
+#         'TIMEOUT': 5000,
+#         # This setting will not work as intended with the ElasticSearch provided by http://www.searchly.com/
+#         # 'ATOMIC_REBUILD': True,
+#         'HOSTS': [{
+#             'host': get_env_variable('ELASTICSEARCH_HOST'),
+#             'port': get_env_variable('ELASTICSEARCH_PORT'),
+#             'http_auth': (get_env_variable('ELASTICSEARCH_USER'), get_env_variable('ELASTICSEARCH_PASSWORD')),
+#             'use_ssl': True,
+#             'verify_certs': False,
+#         }]
+#     },
+# }
 WAGTAILSEARCH_BACKENDS = {
     'default': {
-        'BACKEND': 'wagtail.search.backends.elasticsearch2',
-        'INDEX': get_env_variable('ELASTICSEARCH_INDEX'),
-        'TIMEOUT': 5000,
-        # This setting will not work as intended with the ElasticSearch provided by http://www.searchly.com/
-        # 'ATOMIC_REBUILD': True,
-        'HOSTS': [{
-            'host': get_env_variable('ELASTICSEARCH_HOST'),
-            'port': get_env_variable('ELASTICSEARCH_PORT'),
-            'http_auth': (get_env_variable('ELASTICSEARCH_USER'), get_env_variable('ELASTICSEARCH_PASSWORD')),
-            'use_ssl': True,
-            'verify_certs': False,
-        }]
-    },
+        'BACKEND': 'wagtail.search.backends.db',
+    }
 }
 
 AWS_ACCESS_KEY_ID = get_env_variable('AWS_ACCESS_KEY_ID')


### PR DESCRIPTION
Elasticsearch results are not currently being updated. Will investigate further, but reverting back to the database for now so admin has the ability to search for newer results.