### PR TITLE
fix: Remove Cloudflare cache invalidator from Wagtail

### DIFF
--- a/caching/invalidate.py
+++ b/caching/invalidate.py
@@ -42,12 +42,15 @@ def cloudflare_request(method, url, data):
     }
 
     resp = method(url, json=data, headers=headers)
+
     try:
         resp_json = resp.json()
     except ValueError:
         logger.error('Cloudflare API Error: Unable to parse response into JSON. {}'.format(resp.content))
         return None
 
+
+    logger(resp_json)
     if resp_json['success'] is False:
         logger.error('Cloudflare API Error: Request did not succeed. {}'.format(resp_json))
         return None

--- a/caching/invalidate.py
+++ b/caching/invalidate.py
@@ -42,15 +42,12 @@ def cloudflare_request(method, url, data):
     }
 
     resp = method(url, json=data, headers=headers)
-
     try:
         resp_json = resp.json()
     except ValueError:
         logger.error('Cloudflare API Error: Unable to parse response into JSON. {}'.format(resp.content))
         return None
 
-
-    print(resp_json)
     if resp_json['success'] is False:
         logger.error('Cloudflare API Error: Request did not succeed. {}'.format(resp_json))
         return None

--- a/caching/invalidate.py
+++ b/caching/invalidate.py
@@ -50,7 +50,7 @@ def cloudflare_request(method, url, data):
         return None
 
 
-    logger(resp_json)
+    logger.info(resp_json)
     if resp_json['success'] is False:
         logger.error('Cloudflare API Error: Request did not succeed. {}'.format(resp_json))
         return None

--- a/caching/invalidate.py
+++ b/caching/invalidate.py
@@ -4,54 +4,8 @@ import logging
 
 import requests
 from django.conf import settings
-from django.db.models.signals import pre_delete
-from django.dispatch import receiver
-from wagtail.contrib.frontend_cache.utils import purge_page_from_cache
-from wagtail.core.signals import page_published
-
-from articles import models as articles_models
-from core.models import HomePage
-from events.models import EventListPage, EventPage
-from jobs.models import JobPostingListPage, JobPostingPage
-from newsletter.models import NewsletterListPage, NewsletterPage
-from people.models import ContributorListPage, ContributorPage
-from six.moves import xrange
 
 logger = logging.getLogger(__name__)
-
-# for cache invalidation of index pages
-invalidation_map = {
-    JobPostingPage: [JobPostingListPage],
-
-    EventPage: [EventListPage],
-
-    ContributorPage: [ContributorListPage],
-
-    NewsletterPage: [NewsletterListPage],
-
-    articles_models.ArticlePage: [
-        articles_models.ArticleListPage,
-        articles_models.TopicListPage,
-        articles_models.SeriesListPage,
-        HomePage
-    ],
-
-    articles_models.SeriesPage: [
-        articles_models.ArticleListPage,
-        articles_models.TopicListPage,
-        articles_models.SeriesListPage,
-        HomePage,
-    ],
-
-    articles_models.ExternalArticlePage: [
-        articles_models.ArticleListPage,
-        HomePage,
-    ]
-}
-
-
-# TODO: Invalidate related pages when possible.
-
 
 _cloudflare_config = None
 
@@ -109,45 +63,3 @@ def cloudflare_purge_all():
         '/zones/{ZONEID}/purge_cache',
         data,
     )
-
-
-# From http://stackoverflow.com/a/434328/91243
-def chunker(seq, size):
-    return (seq[pos:pos + size] for pos in xrange(0, len(seq), size))
-
-
-def cloudflare_purge_urls(urls):
-    if not isinstance(urls, list):
-        urls = [urls]
-
-    for urls in chunker(urls, 30):
-        data = {"files": urls}
-
-        cloudflare_request(
-            requests.delete,
-            '/zones/{ZONEID}/purge_cache',
-            data,
-        )
-
-
-def purge_related(instance):
-    global invalidation_map
-    instance_model = instance.__class__
-    if instance_model not in invalidation_map:
-        return
-    for related_page_model in invalidation_map[instance_model]:
-        for page in related_page_model.objects.live():
-            print("Purging {}".format(page))
-            purge_page_from_cache(page)
-
-
-@receiver(page_published)
-def page_published_handler(instance, **kwargs):
-    cloudflare_purge_all()
-    # purge_related(instance)
-
-
-@receiver(pre_delete)
-def page_deleted_handler(instance, **kwargs):
-    cloudflare_purge_all()
-    # purge_related(instance)

--- a/caching/invalidate.py
+++ b/caching/invalidate.py
@@ -50,7 +50,7 @@ def cloudflare_request(method, url, data):
         return None
 
 
-    logger.info(resp_json)
+    print(resp_json)
     if resp_json['success'] is False:
         logger.error('Cloudflare API Error: Request did not succeed. {}'.format(resp_json))
         return None

--- a/opencanada/settings/production.py
+++ b/opencanada/settings/production.py
@@ -55,7 +55,6 @@ RAVEN_CONFIG = {
 }
 
 INSTALLED_APPS = INSTALLED_APPS + (
-    'wagtail.contrib.frontend_cache',
     'raven.contrib.django.raven_compat',
     # 'interactives_content',
     'caching',


### PR DESCRIPTION
Remove Wagtail's [frontend cache invalidator](https://docs.wagtail.io/en/v2.1.3/reference/contrib/frontendcache.html), as this is returning errors from Cloudflare such as [this one](https://sentry.io/the-centre-for-international-g/opencanada/issues/858277776).

We don't need this functionality, so Som has asked to remove it to simplify the app.

The ability to clear the Cloudflare cache through the "Clear Cache" button on admin still works.