### PR TITLE
feat: Remove prefix from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Use Python 3.6+ and Django 1.11.x for best results.
     -  for development: `pip install -r requirements/dev.txt`
 
 ## Required Environment Variables
-OPEN_CANADA_SECRET_KEY - The django SECRET_KEY setting.
+SECRET_KEY - The django SECRET_KEY setting.
 Set environment variable in bash
 
-OPEN_CANADA_BASE_URL - Base URL to use when referring to full URLs within the
+BASE_URL - Base URL to use when referring to full URLs within the
 Wagtail admin backend. e.g. in notification emails. Don't include '/admin' or
 a trailing slash.
 

--- a/manage.py
+++ b/manage.py
@@ -10,11 +10,11 @@ with warnings.catch_warnings():
     dotenv.read_dotenv()
 
 if __name__ == "__main__":
-    if os.environ.get('OPEN_CANADA_PYTHON_ENV') == 'production':
+    if os.environ.get('PYTHON_ENV') == 'production':
         os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'opencanada.settings.production')
-    elif os.environ.get('OPEN_CANADA_PYTHON_ENV') == 'admin':
+    elif os.environ.get('PYTHON_ENV') == 'admin':
         os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'opencanada.settings.admin')
-    elif os.environ.get('OPEN_CANADA_PYTHON_ENV') == 'staging':
+    elif os.environ.get('PYTHON_ENV') == 'staging':
         os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'opencanada.settings.staging')
     else:
         os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'opencanada.settings')

--- a/opencanada/settings/base.py
+++ b/opencanada/settings/base.py
@@ -16,15 +16,12 @@ from os.path import abspath, dirname, join
 
 from django.core.exceptions import ImproperlyConfigured
 
-_variable_prefix = "OPEN_CANADA_"
-
-
 def get_env_variable(var_name, default='', required=True):
     try:
-        return environ[_variable_prefix + var_name]
+        return environ[var_name]
     except KeyError:
         if required:
-            error_msg = "Set the {} environment variable.".format(_variable_prefix + var_name)
+            error_msg = "Set the {} environment variable.".format(var_name)
             raise ImproperlyConfigured(error_msg)
         else:
             return default

--- a/opencanada/settings/production.py
+++ b/opencanada/settings/production.py
@@ -74,7 +74,7 @@ FAVICON_PATH = STATIC_URL + 'img/favicon.png'
 CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': get_env_variable('REDIS_CACHE_ENDPOINT'),
+        'LOCATION': get_env_variable('REDIS_URL'),
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
         }

--- a/opencanada/wsgi.py
+++ b/opencanada/wsgi.py
@@ -11,9 +11,9 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-if os.environ.get('OPEN_CANADA_PYTHON_ENV') == 'staging':
+if os.environ.get('PYTHON_ENV') == 'staging':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'opencanada.settings.staging')
-elif os.environ.get('OPEN_CANADA_PYTHON_ENV') == 'admin':
+elif os.environ.get('PYTHON_ENV') == 'admin':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'opencanada.settings.admin')
 else:
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'opencanada.settings.production')


### PR DESCRIPTION
Heroku automatically adds an environment variable when provisioning an add-on. It would be nice to simply use that environment variable than copy the value to another environment variable beginning with `OPEN_CANADA_`.

We would only want to have prefixes per django app if we were running multiple applications on the same server, but that's not relevant with Heroku, so there's no need for the prefix anymore.